### PR TITLE
Add docker compose stack with UI, registry, analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.8] - 2026-01-24
+
+### Added
+- Docker Compose stack for API, Streamlit UI, and policy registry.
+- Optional analytics profile with Prometheus + Grafana.
+- `/metrics` endpoint for Prometheus scraping.
+
+### Changed
+- Documentation updated for the compose stack and new diagrams.
+
 ## [0.2.7] - 2026-01-24
 
 ### Added

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY pyproject.toml README.md streamlit_app.py /app/
+COPY src /app/src
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+EXPOSE 8501
+
+CMD ["streamlit", "run", "streamlit_app.py", "--server.address", "0.0.0.0", "--server.port", "8501"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ flowchart LR
 - MCP tools for scan, metadata, and snippet generation
 - Streamlit and web UI for instant reporting
 - Dockerized REST API for CI/CD adoption
+- Docker Compose dev stack (API + UI + policy registry, optional analytics)
 
 ## Supported Providers
 
@@ -142,6 +143,7 @@ Legend: <span style="color: green">✅ Delivered</span> • <span style="color: 
 | --- | --- | --- | --- | --- |
 | Dockerized MCP + REST API | <span style="color: green">✅ Delivered (0.2.x)</span> |  |  |  |
 | CLI-first install | <span style="color: green">✅ Delivered (0.2.x)</span> |  |  |  |
+| Docker Compose local stack (API + UI + registry) | <span style="color: green">✅ Delivered (0.2.x)</span> |  |  |  |
 | GitHub Action pre-apply / PR checks | <span style="color: orange">🚧 Planned</span> |  |  |  |
 | Azure DevOps / Pipeline extension | <span style="color: orange">🚧 Planned</span> |  |  |  |
 | Policy layering model (base → env → app) | <span style="color: orange">🚧 Planned</span> |  |  |  |
@@ -215,7 +217,7 @@ terraform-guardrail web
 pip install terraform-guardrail
 ```
 
-PyPI: https://pypi.org/project/terraform-guardrail/ (latest: 0.2.7)
+PyPI: https://pypi.org/project/terraform-guardrail/ (latest: 0.2.8)
 
 ## CLI examples
 
@@ -261,6 +263,7 @@ docker run --rm -p 8080:8080 terraform-guardrail
 API endpoints:
 
 - `GET /health`
+- `GET /metrics`
 - `POST /scan`
 - `POST /provider-metadata`
 - `POST /generate-snippet`
@@ -278,13 +281,55 @@ curl -X POST http://localhost:8080/scan \\
 Pull the published container image (built on release tags):
 
 ```bash
-docker pull ghcr.io/huzefaaa2/terraform-guardrail:v0.2.7
+docker pull ghcr.io/huzefaaa2/terraform-guardrail:v0.2.8
 ```
 
 Run it:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/huzefaaa2/terraform-guardrail:v0.2.7
+docker run --rm -p 8080:8080 ghcr.io/huzefaaa2/terraform-guardrail:v0.2.8
+```
+
+## Docker Compose Stack (Local Dev)
+
+Bring up API + Streamlit UI + policy registry:
+
+```bash
+docker compose up --build
+```
+
+Enable optional analytics (Prometheus + Grafana):
+
+```bash
+docker compose --profile analytics up --build
+```
+
+Service URLs:
+
+- API: http://localhost:8080
+- Streamlit UI: http://localhost:8501
+- Policy registry (static): http://localhost:8081
+- Prometheus (analytics profile): http://localhost:9090
+- Grafana (analytics profile): http://localhost:3000 (admin / guardrail)
+
+```mermaid
+flowchart LR
+    subgraph ComposeStack[Docker Compose Stack]
+        UI([Streamlit UI])
+        API([REST API])
+        REG[(Policy Registry)]
+        PROM[[Prometheus]]
+        GRAF[[Grafana]]
+    end
+    UI --> API
+    API -.-> REG
+    API --> PROM
+    PROM --> GRAF
+
+    classDef core fill:#e8f5e9,stroke:#2e7d32,stroke-width:1px,color:#1b5e20;
+    classDef optional fill:#fff3e0,stroke:#ef6c00,stroke-width:1px,color:#e65100;
+    class UI,API,REG core;
+    class PROM,GRAF optional;
 ```
 
 ## Release Links
@@ -323,8 +368,8 @@ make changelog
 ### Release Helpers
 
 ```bash
-make release-dry VERSION=0.2.7
-make version-bump VERSION=0.2.7
+make release-dry VERSION=0.2.8
+make version-bump VERSION=0.2.8
 ```
 
 ## MCP tools (current)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,8 @@
 
 | Version | Date (UTC) | Highlights |
 | --- | --- | --- |
+| 0.2.8 | 2026-01-24 | Docker Compose stack (API + UI + policy registry) and optional analytics |
+| 0.2.7 | 2026-01-24 | GHCR publishing fixes, manual workflow dispatch |
 | 0.2.6 | 2026-01-01 | Docker image publishing, REST API container workflow, release table added |
 | 0.2.5 | 2026-01-01 | PyPI-friendly README update, diagram links for PyPI |
 | 0.2.4 | 2026-01-01 | Multi-file Streamlit scan, CSV export with file metadata |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,14 @@
-# v0.2.7
+# v0.2.8
 
 ## Highlights
-- GHCR container publishing fixed and validated on tag releases.
+- Docker Compose stack for API, Streamlit UI, and policy registry.
+- Optional analytics profile with Prometheus + Grafana.
 
 ## Added
-- Manual workflow dispatch support for CI and container workflows.
+- `/metrics` endpoint for Prometheus scraping.
+- Streamlit Dockerfile for the UI container.
+- Policy registry stub assets for local policy pack hosting.
+- Compose documentation in README and Wiki.
 
 ## Changed
-- Version bump to `0.2.7`.
+- Version bump to `0.2.8`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+name: terraform-guardrail
+
+services:
+  guardrail-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: terraform-guardrail-api:local
+    ports:
+      - "8080:8080"
+    environment:
+      - GUARDRAIL_POLICY_REGISTRY_URL=http://policy-registry:80
+
+  guardrail-ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.streamlit
+    image: terraform-guardrail-ui:local
+    ports:
+      - "8501:8501"
+    depends_on:
+      - guardrail-api
+
+  policy-registry:
+    image: nginx:alpine
+    ports:
+      - "8081:80"
+    volumes:
+      - ./ops/policy-registry:/usr/share/nginx/html:ro
+
+  prometheus:
+    image: prom/prometheus:latest
+    profiles: ["analytics"]
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./ops/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:latest
+    profiles: ["analytics"]
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=guardrail
+    volumes:
+      - ./ops/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -71,3 +71,25 @@ flowchart LR
     CI --> GUARDRAIL
     ADO --> GUARDRAIL
 ```
+
+## Docker Compose Stack (Local Dev)
+
+```mermaid
+flowchart LR
+    subgraph ComposeStack[Docker Compose Stack]
+        UI([Streamlit UI])
+        API([REST API])
+        REG[(Policy Registry)]
+        PROM[[Prometheus]]
+        GRAF[[Grafana]]
+    end
+    UI --> API
+    API -.-> REG
+    API --> PROM
+    PROM --> GRAF
+
+    classDef core fill:#e8f5e9,stroke:#2e7d32,stroke-width:1px,color:#1b5e20;
+    classDef optional fill:#fff3e0,stroke:#ef6c00,stroke-width:1px,color:#e65100;
+    class UI,API,REG core;
+    class PROM,GRAF optional;
+```

--- a/docs/wiki/CLI-Usage.md
+++ b/docs/wiki/CLI-Usage.md
@@ -14,7 +14,7 @@ pip install -e ".[dev]"
 pip install terraform-guardrail
 ```
 
-PyPI: https://pypi.org/project/terraform-guardrail/ (latest: 0.2.7)
+PyPI: https://pypi.org/project/terraform-guardrail/ (latest: 0.2.8)
 
 ## Scan
 

--- a/docs/wiki/Diagrams.md
+++ b/docs/wiki/Diagrams.md
@@ -28,6 +28,28 @@ flowchart LR
     ADO --> GUARDRAIL
 ```
 
+## Docker Compose Stack (Local Dev)
+
+```mermaid
+flowchart LR
+    subgraph ComposeStack[Docker Compose Stack]
+        UI([Streamlit UI])
+        API([REST API])
+        REG[(Policy Registry)]
+        PROM[[Prometheus]]
+        GRAF[[Grafana]]
+    end
+    UI --> API
+    API -.-> REG
+    API --> PROM
+    PROM --> GRAF
+
+    classDef core fill:#e8f5e9,stroke:#2e7d32,stroke-width:1px,color:#1b5e20;
+    classDef optional fill:#fff3e0,stroke:#ef6c00,stroke-width:1px,color:#e65100;
+    class UI,API,REG core;
+    class PROM,GRAF optional;
+```
+
 ## High-Level Architecture
 
 ```mermaid

--- a/docs/wiki/Docker-Compose.md
+++ b/docs/wiki/Docker-Compose.md
@@ -1,0 +1,30 @@
+# Docker Compose Stack
+
+Terraform Guardrail MCP ships with a local Docker Compose stack that brings up the REST API, the
+Streamlit UI, and a lightweight policy registry. Optional analytics (Prometheus + Grafana) can be
+enabled via Compose profiles.
+
+## Start the stack
+
+```bash
+docker compose up --build
+```
+
+## Enable analytics
+
+```bash
+docker compose --profile analytics up --build
+```
+
+## Service URLs
+
+- API: http://localhost:8080
+- Streamlit UI: http://localhost:8501
+- Policy registry: http://localhost:8081
+- Prometheus: http://localhost:9090 (analytics profile)
+- Grafana: http://localhost:3000 (analytics profile, admin / guardrail)
+
+## Notes
+
+- The policy registry is a static stub used to demonstrate policy pack hosting.
+- The API exposes `/metrics` for Prometheus scraping.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -28,15 +28,17 @@ flowchart LR
 - [MCP Server](MCP-Server.md)
 - [Compliance Rules](Compliance-Rules.md)
 - [Streamlit Deployment](Streamlit-Deployment.md)
+- [Docker Compose Stack](Docker-Compose.md)
 - [Live Streamlit App](https://terraform-guardrail.streamlit.app/)
 - [PyPI Package](https://pypi.org/project/terraform-guardrail/)
 - [Release Process](Release-Process.md)
 
 ## Latest Release
 
-- Version: 0.2.7
+- Version: 0.2.8
 - Container image: https://github.com/Huzefaaa2/terraform-guardrail/pkgs/container/terraform-guardrail
 - Supported providers: AWS, Azure, GCP, Kubernetes, Helm, OCI, Vault, Alicloud, vSphere
+- Local stack: Docker Compose (API + UI + policy registry, optional analytics)
 
 ## Feature Matrix
 

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -9,6 +9,7 @@ Legend: <span style="color: green">✅ Delivered</span> • <span style="color: 
 | --- | --- | --- | --- | --- |
 | Dockerized MCP + REST API | <span style="color: green">✅ Delivered (0.2.x)</span> |  |  |  |
 | CLI-first install | <span style="color: green">✅ Delivered (0.2.x)</span> |  |  |  |
+| Docker Compose local stack (API + UI + registry) | <span style="color: green">✅ Delivered (0.2.x)</span> |  |  |  |
 | GitHub Action pre-apply / PR checks | <span style="color: orange">🚧 Planned</span> |  |  |  |
 | Azure DevOps / Pipeline extension | <span style="color: orange">🚧 Planned</span> |  |  |  |
 | Policy layering model (base → env → app) | <span style="color: orange">🚧 Planned</span> |  |  |  |

--- a/ops/grafana/provisioning/datasources/datasource.yml
+++ b/ops/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/ops/policy-registry/index.html
+++ b/ops/policy-registry/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Terraform Guardrail Policy Registry</title>
+    <style>
+      body {
+        font-family: "Segoe UI", Arial, sans-serif;
+        margin: 40px;
+        color: #1b1b1b;
+      }
+      code {
+        background: #f6f8fa;
+        padding: 2px 6px;
+        border-radius: 4px;
+      }
+      .card {
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 16px 20px;
+        background: #fafafa;
+        max-width: 680px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Terraform Guardrail Policy Registry</h1>
+    <div class="card">
+      <p>
+        This is a lightweight, static policy registry for local development. It mirrors the
+        planned registry service by hosting policy packs and metadata that Guardrail can consume.
+      </p>
+      <p>Try fetching the registry index:</p>
+      <p><code>/registry.json</code></p>
+      <p>Sample pack path:</p>
+      <p><code>/packs/baseline/README.md</code></p>
+    </div>
+  </body>
+</html>

--- a/ops/policy-registry/packs/baseline/README.md
+++ b/ops/policy-registry/packs/baseline/README.md
@@ -1,0 +1,4 @@
+# Baseline Guardrails
+
+This pack is a placeholder for baseline policies. It exists to demonstrate how policy packs can be
+versioned, hosted, and referenced from the registry.

--- a/ops/policy-registry/registry.json
+++ b/ops/policy-registry/registry.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.1",
+  "packs": [
+    {
+      "id": "baseline",
+      "title": "Baseline guardrails",
+      "description": "Starter guardrails for secrets, schema usage, and hygiene.",
+      "path": "/packs/baseline/README.md"
+    }
+  ]
+}

--- a/ops/prometheus/prometheus.yml
+++ b/ops/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: guardrail-api
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - guardrail-api:8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "terraform-guardrail"
-version = "0.2.7"
+version = "0.2.8"
 description = "MCP-backed Terraform assistant with ephemeral-values compliance."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "fastapi>=0.110",
+  "prometheus-client>=0.20",
   "uvicorn>=0.27",
   "typer>=0.12",
   "rich>=13.7",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,13 @@ def test_health_endpoint() -> None:
     assert response.json() == {"status": "ok"}
 
 
+def test_metrics_endpoint() -> None:
+    client = TestClient(create_app())
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "guardrail_requests_total" in response.text
+
+
 def test_generate_snippet_endpoint() -> None:
     client = TestClient(create_app())
     response = client.post(


### PR DESCRIPTION
## Summary\n- add Docker Compose stack for API + Streamlit UI + policy registry\n- add optional analytics profile (Prometheus + Grafana) with /metrics endpoint\n- update README and wiki docs, bump version to 0.2.8\n\n## Testing\n- ruff check .\n- pytest